### PR TITLE
do not publish root package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@wbce/orbits",
   "version": "1.0.0",
   "description": "Flow for DevOps - a simple way to write state machine",
+  "private": true,
   "scripts": {
     "generate-doc": "npx typedoc --options typedoc.ts",
     "ci:publish": "pnpm publish -r"


### PR DESCRIPTION
## Change description

Adding private in the root package allows to avoid publishing it during the ci/cd process

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues
 
Error in CI/CD: publishing try to publish root package and fails

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [ ] reviewers assigned
