### PR TITLE
Fix orbits-cli unable to run

### DIFF
--- a/.changeset/nasty-socks-clap.md
+++ b/.changeset/nasty-socks-clap.md
@@ -1,0 +1,6 @@
+---
+'@orbi-ts/core': patch
+'@orbi-ts/cli': patch
+---
+
+Fix cli run

--- a/cli/bin/index.ts
+++ b/cli/bin/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env -S npx tsx
 import path from 'path';
 import { fileURLToPath } from 'url';
 

--- a/cli/src/commands/run.ts
+++ b/cli/src/commands/run.ts
@@ -241,8 +241,10 @@ const run = async (
                     process.stdout.write(
                         `${action.dbDoc.actionRef} completed with state ${colors.bold(ActionState[state as ActionState])}\n`
                     );
-                    process.stdout.write(
-                        colors.yellow(`You can now close this process\n`)
+                    process.exit(
+                        state === ActionState.SUCCESS
+                            ? exitCodes.SUCCESS
+                            : exitCodes.GENERIC_ERROR
                     );
                 } else {
                     watchAction(

--- a/core/actions/src/runtime/db-connection.ts
+++ b/core/actions/src/runtime/db-connection.ts
@@ -34,6 +34,10 @@ export function setDbConnection(runtime: ActionRuntime) {
         runtime.ResourceModel = runtime.db.mongo.conn.model<
             ResourceSchemaInterface<any, any>
         >('Resource', resourceSchema);
+        runtime.LogModel = runtime.db.mongo.conn.model<LogSchemaInterface>(
+            'Log',
+            logSchema
+        );
         return;
     }
     const conn = mongoose.createConnection(

--- a/core/actions/src/runtime/logger.ts
+++ b/core/actions/src/runtime/logger.ts
@@ -70,6 +70,9 @@ const filterPertinentInfo = winston.format((info: any) => {
 
 class MongoTransporter extends Transport {
     public log(info: any, next: () => void) {
+        // as the logger can try to log before the runtime connection is active and LogModel defined,
+        // simply ignore
+        if (!ActionRuntime.activeRuntime.LogModel) return;
         const log = new ActionRuntime.activeRuntime.LogModel({
             ...info,
             filter: ActionRuntime.activeRuntime.actionFilter,


### PR DESCRIPTION
## Change description

Fixes an issue where LogModel is not defined at the start so any try to log results in an error. This prevented the cli to run.

## Type of change
- [x] Bug fix (fixes an issue)
- [] New feature (adds functionality)

## Related issues
 

## Checklists

### Development

- [x] Lint rules pass locally
- [x]  Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer. Screenshots or screencasts are attached as necessary
- [x] reviewers assigned
